### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Kolade Olorunnife
 maintainer=Kolade Olorunnife <electrotech14@hotmail.com>
 sentence=Arduino library for using the Adafruit datalogging shield
 paragraph=Arduino library for using the Adafruit datalogging shield
-category=Storage
+category=Data Storage
 url=https://github.com/KoolaidDaBeast/Simple-SD-Card-Library
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category 'Storage' in library Simple SD Card Library is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format