### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,20 +6,20 @@
 # Datatypes (KEYWORD1)
 ###########################################
 
-chipSelect KEYWORD1
+chipSelect	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)
 ###########################################
 
-writeToFile KEYWORD2
-writeNewLineToFile KEYWORD2
-createIncrFile KEYWORD2
-createFile KEYWORD2
-setupSDCard KEYWORD2
-openFile KEYWORD2
-closeFile KEYWORD2
-getTimestamp KEYWORD2
-getMillis KEYWORD2
-delayLogs KEYWORD2
-isSynced KEYWORD2
+writeToFile	KEYWORD2
+writeNewLineToFile	KEYWORD2
+createIncrFile	KEYWORD2
+createFile	KEYWORD2
+setupSDCard	KEYWORD2
+openFile	KEYWORD2
+closeFile	KEYWORD2
+getTimestamp	KEYWORD2
+getMillis	KEYWORD2
+delayLogs	KEYWORD2
+isSynced	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords